### PR TITLE
feat(http-status): added HTTP server with status

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -215,13 +215,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b829e4e32b91e643de6eafe82b1d90675f5874230191a4ffbc1b336dec4d6bf"
 dependencies = [
  "async-trait",
- "axum-core",
+ "axum-core 0.3.4",
  "bitflags 1.3.2",
  "bytes 1.7.1",
  "futures-util",
- "http",
- "http-body",
- "hyper",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.30",
  "itoa",
  "matchit",
  "memchr",
@@ -230,10 +230,44 @@ dependencies = [
  "pin-project-lite",
  "rustversion",
  "serde",
- "sync_wrapper",
+ "sync_wrapper 0.1.2",
  "tower",
  "tower-layer",
  "tower-service",
+]
+
+[[package]]
+name = "axum"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a6c9af12842a67734c9a2e355436e5d03b22383ed60cf13cd0c18fbfe3dcbcf"
+dependencies = [
+ "async-trait",
+ "axum-core 0.4.3",
+ "bytes 1.7.1",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.4.1",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper 1.0.1",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -245,12 +279,33 @@ dependencies = [
  "async-trait",
  "bytes 1.7.1",
  "futures-util",
- "http",
- "http-body",
+ "http 0.2.12",
+ "http-body 0.4.6",
  "mime",
  "rustversion",
  "tower-layer",
  "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a15c63fd72d41492dc4f497196f5da1fb04fb7529e631d73630d1b491e47a2e3"
+dependencies = [
+ "async-trait",
+ "bytes 1.7.1",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper 0.1.2",
+ "tower-layer",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -1262,7 +1317,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "http",
+ "http 0.2.12",
  "indexmap 2.4.0",
  "slab",
  "tokio",
@@ -1352,13 +1407,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
+dependencies = [
+ "bytes 1.7.1",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
 name = "http-body"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
 dependencies = [
  "bytes 1.7.1",
- "http",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes 1.7.1",
+ "http 1.1.0",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
+dependencies = [
+ "bytes 1.7.1",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.1",
  "pin-project-lite",
 ]
 
@@ -1391,8 +1480,8 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http",
- "http-body",
+ "http 0.2.12",
+ "http-body 0.4.6",
  "httparse",
  "httpdate",
  "itoa",
@@ -1405,15 +1494,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50dfd22e0e76d0f662d429a5f80fcaf3855009297eab6a0a9f8543834744ba05"
+dependencies = [
+ "bytes 1.7.1",
+ "futures-channel",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+]
+
+[[package]]
 name = "hyper-timeout"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
 dependencies = [
- "hyper",
+ "hyper 0.14.30",
  "pin-project-lite",
  "tokio",
  "tokio-io-timeout",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cde7055719c54e36e95e8719f95883f22072a48ede39db7fc17a4e1d5281e9b9"
+dependencies = [
+ "bytes 1.7.1",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "hyper 1.4.1",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -2688,6 +2811,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af99884400da37c88f5e9146b7f1fd0fbcae8f6eec4e9da38b67d05486f814a6"
+dependencies = [
+ "itoa",
+ "serde",
+]
+
+[[package]]
 name = "serde_repr"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2704,6 +2837,18 @@ version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb5b1b31579f3811bf615c144393417496f152e12ac8b7663bf664f4a815306d"
 dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
  "serde",
 ]
 
@@ -2945,6 +3090,12 @@ name = "sync_wrapper"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
 
 [[package]]
 name = "synstructure"
@@ -3683,15 +3834,15 @@ checksum = "8f219fad3b929bef19b1f86fbc0358d35daed8f2cac972037ac0dc10bbb8d5fb"
 dependencies = [
  "async-stream",
  "async-trait",
- "axum",
+ "axum 0.6.20",
  "base64 0.13.1",
  "bytes 1.7.1",
  "futures-core",
  "futures-util",
  "h2",
- "http",
- "http-body",
- "hyper",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.30",
  "hyper-timeout",
  "percent-encoding",
  "pin-project 1.1.5",
@@ -4263,6 +4414,7 @@ name = "xtrgpuminer"
 version = "0.1.7-pre.4"
 dependencies = [
  "anyhow",
+ "axum 0.7.5",
  "clap 4.5.16",
  "cust",
  "libsqlite3-sys",
@@ -4282,7 +4434,9 @@ dependencies = [
  "tari_crypto",
  "tari_key_manager",
  "tari_script",
+ "tari_shutdown",
  "tari_utilities",
+ "thiserror",
  "tokio",
  "tonic",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ tari_common_types = { git = "http://github.com/tari-project/tari", tag = "v1.2.0
 tari_common = { git = "http://github.com/tari-project/tari", tag = "v1.2.0-pre.0" }
 tari_script = { git = "http://github.com/tari-project/tari", tag = "v1.2.0-pre.0" }
 tari_key_manager = { git = "http://github.com/tari-project/tari", tag = "v1.2.0-pre.0" }
+tari_shutdown = { git = "https://github.com/tari-project/tari.git", tag = "v1.2.0-pre.0" }
 tari_crypto = { version = "0.20.3", features = ["borsh"] }
 tari_utilities = "0.7"
 serde = { version = "1.0.130", features = ["derive"] }
@@ -32,6 +33,8 @@ libsqlite3-sys = { version = "0.25.1", features = ["bundled"] }
 cust = { version = "0.3.2", optional = true }
 opencl3 = { version = "0.9.5", optional = true }
 opencl-sys = "*"
+axum = "0.7.5"
+thiserror = "1.0.63"
 
 [features]
 default = []

--- a/src/config_file.rs
+++ b/src/config_file.rs
@@ -9,6 +9,8 @@ pub(crate) struct ConfigFile {
     pub coinbase_extra: String,
     pub template_refresh_secs: u64,
     pub p2pool_enabled: bool,
+    pub http_server_enabled: bool,
+    pub http_server_port: u16,
 }
 
 impl Default for ConfigFile {
@@ -19,6 +21,8 @@ impl Default for ConfigFile {
             coinbase_extra: "tari_gpu_miner".to_string(),
             template_refresh_secs: 30,
             p2pool_enabled: false,
+            http_server_enabled: true,
+            http_server_port: 18000,
         }
     }
 }

--- a/src/http/config.rs
+++ b/src/http/config.rs
@@ -1,0 +1,15 @@
+pub struct Config {
+    pub port: u16,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self { port: 18000 }
+    }
+}
+
+impl Config {
+    pub fn new(port: u16) -> Self {
+        Self { port }
+    }
+}

--- a/src/http/handlers/health.rs
+++ b/src/http/handlers/health.rs
@@ -1,0 +1,8 @@
+// Copyright 2024 The Tari Project
+// SPDX-License-Identifier: BSD-3-Clause
+
+use axum::http::StatusCode;
+
+pub async fn handle_health() -> Result<StatusCode, StatusCode> {
+    Ok(StatusCode::OK)
+}

--- a/src/http/handlers/mod.rs
+++ b/src/http/handlers/mod.rs
@@ -1,0 +1,4 @@
+pub mod health;
+
+pub mod stats;
+pub mod version;

--- a/src/http/handlers/stats.rs
+++ b/src/http/handlers/stats.rs
@@ -7,10 +7,14 @@ use serde::{Deserialize, Serialize};
 #[derive(Serialize, Deserialize)]
 pub struct Stats {
     pub hashes_per_second: u64,
+    pub accepted_blocks: u64,
+    pub rejected_blocks: u64,
 }
 
 pub async fn handle_get_stats(State(state): State<AppState>) -> Result<Json<Stats>, StatusCode> {
     Ok(Json(Stats {
         hashes_per_second: state.stats_store.hashes_per_second(),
+        accepted_blocks: state.stats_store.accepted_blocks(),
+        rejected_blocks: state.stats_store.rejected_blocks(),
     }))
 }

--- a/src/http/handlers/stats.rs
+++ b/src/http/handlers/stats.rs
@@ -1,0 +1,16 @@
+use crate::http::server::AppState;
+use axum::extract::State;
+use axum::http::StatusCode;
+use axum::Json;
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize)]
+pub struct Stats {
+    pub hashes_per_second: u64,
+}
+
+pub async fn handle_get_stats(State(state): State<AppState>) -> Result<Json<Stats>, StatusCode> {
+    Ok(Json(Stats {
+        hashes_per_second: state.stats_store.hashes_per_second(),
+    }))
+}

--- a/src/http/handlers/version.rs
+++ b/src/http/handlers/version.rs
@@ -1,0 +1,10 @@
+// Copyright 2024 The Tari Project
+// SPDX-License-Identifier: BSD-3-Clause
+
+use axum::http::StatusCode;
+
+const VERSION: &str = env!("CARGO_PKG_VERSION");
+
+pub async fn handle_version() -> Result<String, StatusCode> {
+    Ok(VERSION.to_string())
+}

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -1,0 +1,3 @@
+pub mod config;
+mod handlers;
+pub mod server;

--- a/src/http/server.rs
+++ b/src/http/server.rs
@@ -1,0 +1,62 @@
+use crate::http::config;
+use crate::http::handlers::{health, stats, version};
+use crate::stats_store::StatsStore;
+use axum::routing::get;
+use axum::Router;
+use std::sync::Arc;
+use tari_shutdown::ShutdownSignal;
+use thiserror::Error;
+use tokio::io;
+
+/// An HTTP server that provides stats and other useful information.
+pub struct HttpServer {
+    shutdown_signal: ShutdownSignal,
+    config: config::Config,
+    stats_store: Arc<StatsStore>,
+}
+
+#[derive(Error, Debug)]
+pub enum Error {
+    #[error("I/O error: {0}")]
+    IO(#[from] io::Error),
+}
+
+#[derive(Clone)]
+pub struct AppState {
+    pub stats_store: Arc<StatsStore>,
+}
+
+impl HttpServer {
+    pub fn new(shutdown_signal: ShutdownSignal, config: config::Config, stats_store: Arc<StatsStore>) -> Self {
+        Self {
+            shutdown_signal,
+            config,
+            stats_store,
+        }
+    }
+
+    pub fn routes(&self) -> Router {
+        Router::new()
+            .route("/health", get(health::handle_health))
+            .route("/version", get(version::handle_version))
+            .route("/stats", get(stats::handle_get_stats))
+            .with_state(AppState {
+                stats_store: self.stats_store.clone(),
+            })
+    }
+
+    /// Starts the http server on the port passed in ['HttpServer::new']
+    pub async fn start(&self) -> Result<(), Error> {
+        let router = self.routes();
+        let listener = tokio::net::TcpListener::bind(format!("0.0.0.0:{}", self.config.port))
+            .await
+            .map_err(Error::IO)?;
+        println!("Starting HTTP server at http://127.0.0.1:{}", self.config.port);
+        axum::serve(listener, router)
+            .with_graceful_shutdown(self.shutdown_signal.clone())
+            .await
+            .map_err(Error::IO)?;
+        println!("HTTP server stopped!");
+        Ok(())
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -120,6 +120,7 @@ async fn main_inner() -> Result<(), anyhow::Error> {
     // start http server
     let mut shutdown = Shutdown::new();
     let stats_store = Arc::new(StatsStore::new());
+    // TODO: port in config should be configurable from gpuminer's own config
     let http_server = HttpServer::new(shutdown.to_signal(), Config::default(), stats_store.clone());
     tokio::spawn(async move {
         if let Err(error) = http_server.start().await {

--- a/src/main.rs
+++ b/src/main.rs
@@ -121,6 +121,7 @@ async fn main_inner() -> Result<(), anyhow::Error> {
     let mut shutdown = Shutdown::new();
     let stats_store = Arc::new(StatsStore::new());
     // TODO: port in config should be configurable from gpuminer's own config
+    // TODO: add accepted/rejected blocks
     let http_server = HttpServer::new(shutdown.to_signal(), Config::default(), stats_store.clone());
     tokio::spawn(async move {
         if let Err(error) = http_server.start().await {

--- a/src/stats_store.rs
+++ b/src/stats_store.rs
@@ -3,12 +3,16 @@ use std::sync::atomic::{AtomicU64, Ordering};
 /// Stats store stores statistics about running miner in memory.
 pub struct StatsStore {
     hashes_per_second: AtomicU64,
+    accepted_blocks: AtomicU64,
+    rejected_blocks: AtomicU64,
 }
 
 impl StatsStore {
     pub fn new() -> Self {
         Self {
             hashes_per_second: AtomicU64::new(0),
+            accepted_blocks: AtomicU64::new(0),
+            rejected_blocks: AtomicU64::new(0),
         }
     }
 
@@ -16,7 +20,23 @@ impl StatsStore {
         self.hashes_per_second.store(new_value, Ordering::SeqCst);
     }
 
+    pub fn inc_accepted_blocks(&self) {
+        self.accepted_blocks.fetch_add(1, Ordering::SeqCst);
+    }
+
+    pub fn inc_rejected_blocks(&self) {
+        self.accepted_blocks.fetch_add(1, Ordering::SeqCst);
+    }
+
     pub fn hashes_per_second(&self) -> u64 {
         self.hashes_per_second.load(Ordering::SeqCst)
+    }
+
+    pub fn accepted_blocks(&self) -> u64 {
+        self.accepted_blocks.load(Ordering::SeqCst)
+    }
+
+    pub fn rejected_blocks(&self) -> u64 {
+        self.rejected_blocks.load(Ordering::SeqCst)
     }
 }

--- a/src/stats_store.rs
+++ b/src/stats_store.rs
@@ -1,0 +1,22 @@
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// Stats store stores statistics about running miner in memory.
+pub struct StatsStore {
+    hashes_per_second: AtomicU64,
+}
+
+impl StatsStore {
+    pub fn new() -> Self {
+        Self {
+            hashes_per_second: AtomicU64::new(0),
+        }
+    }
+
+    pub fn update_hashes_per_second(&self, new_value: u64) {
+        self.hashes_per_second.store(new_value, Ordering::SeqCst);
+    }
+
+    pub fn hashes_per_second(&self) -> u64 {
+        self.hashes_per_second.load(Ordering::SeqCst)
+    }
+}


### PR DESCRIPTION
Added an optional HTTP server which exposes the following endpoints:

- `http://127.0.0.1:18000/health` - health check endpoint, returns simply HTTP 200 OK
- `http://127.0.0.1:18000/version` - returns version of GPU miner in raw string
- `http://127.0.0.1:18000/stats` - Returns stats from running miner

Example response:
```json
{
  "hashes_per_second": 64000000,
  "accepted_blocks": 40,
  "rejected_blocks": 0
}
```