### PR TITLE
feat: create gpu_status json file 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ config.json
 # Ignore OS files
 .DS_Store
 .idea/
+.vscode/*
+!.vscode/extensions.json

--- a/src/engine_impl.rs
+++ b/src/engine_impl.rs
@@ -7,6 +7,8 @@ pub trait EngineImpl {
 
     fn num_devices(&self) -> Result<u32, anyhow::Error>;
 
+    fn list_devices(&self) -> Result<Vec<String>, anyhow::Error>;
+
     fn create_context(&self, device_index: u32) -> Result<Self::Context, anyhow::Error>;
 
     fn create_main_function(&self, context: &Self::Context) -> Result<Self::Function, anyhow::Error>;

--- a/src/engine_impl.rs
+++ b/src/engine_impl.rs
@@ -1,4 +1,4 @@
-use crate::{context_impl::ContextImpl, function_impl::FunctionImpl};
+use crate::{context_impl::ContextImpl, function_impl::FunctionImpl, gpu_status_file::GpuStatus};
 
 pub trait EngineImpl {
     type Context: ContextImpl;
@@ -7,7 +7,7 @@ pub trait EngineImpl {
 
     fn num_devices(&self) -> Result<u32, anyhow::Error>;
 
-    fn list_devices(&self) -> Result<Vec<String>, anyhow::Error>;
+    fn detect_devices(&self) -> Result<Vec<GpuStatus>, anyhow::Error>;
 
     fn create_context(&self, device_index: u32) -> Result<Self::Context, anyhow::Error>;
 

--- a/src/gpu_engine.rs
+++ b/src/gpu_engine.rs
@@ -1,4 +1,4 @@
-use crate::engine_impl::EngineImpl;
+use crate::{engine_impl::EngineImpl, gpu_status_file::GpuStatus};
 
 #[derive(Clone)]
 pub struct GpuEngine<TEngineImpl: EngineImpl> {
@@ -18,8 +18,8 @@ impl<TEngineImpl: EngineImpl> GpuEngine<TEngineImpl> {
         self.inner.num_devices()
     }
 
-    pub fn list_devices(&self) -> Result<Vec<String>, anyhow::Error> {
-        self.inner.list_devices()
+    pub fn detect_devices(&self) -> Result<Vec<GpuStatus>, anyhow::Error> {
+        self.inner.detect_devices()
     }
 
     pub fn create_context(&self, device_index: u32) -> Result<TEngineImpl::Context, anyhow::Error> {

--- a/src/gpu_engine.rs
+++ b/src/gpu_engine.rs
@@ -18,6 +18,10 @@ impl<TEngineImpl: EngineImpl> GpuEngine<TEngineImpl> {
         self.inner.num_devices()
     }
 
+    pub fn list_devices(&self) -> Result<Vec<String>, anyhow::Error> {
+        self.inner.list_devices()
+    }
+
     pub fn create_context(&self, device_index: u32) -> Result<TEngineImpl::Context, anyhow::Error> {
         self.inner.create_context(device_index)
     }

--- a/src/gpu_status_file.rs
+++ b/src/gpu_status_file.rs
@@ -6,37 +6,36 @@ use std::{
 
 use anyhow;
 
-#[derive(serde::Deserialize, serde::Serialize, Debug, Clone)]
-pub(crate) struct GpuStatusFile {
-    pub num_devices: u32,
-    pub device_names: Vec<String>,
+#[derive(serde::Deserialize, serde::Serialize, Debug)]
+pub struct GpuStatus {
+    pub device_name: String,
+    pub is_available: bool,
+}
+
+#[derive(serde::Deserialize, serde::Serialize, Debug)]
+pub struct GpuStatusFile {
+    pub gpu_devices: Vec<GpuStatus>,
 }
 
 impl Default for GpuStatusFile {
     fn default() -> Self {
-        Self {
-            num_devices: 0,
-            device_names: vec![],
-        }
+        Self { gpu_devices: vec![] }
     }
 }
 
 impl GpuStatusFile {
-    pub const fn new(num_devices: u32, device_names: Vec<String>) -> Self {
-        Self {
-            num_devices,
-            device_names,
-        }
+    pub fn new(gpu_devices: Vec<GpuStatus>) -> Self {
+        Self { gpu_devices }
     }
 
-    pub(crate) fn load(path: &PathBuf) -> Result<Self, anyhow::Error> {
+    pub fn load(path: &PathBuf) -> Result<Self, anyhow::Error> {
         let file = File::open(path)?;
         let reader = BufReader::new(file);
         let config = serde_json::from_reader(reader)?;
         Ok(config)
     }
 
-    pub(crate) fn save(&self, path: &Path) -> Result<(), anyhow::Error> {
+    pub fn save(&self, path: &Path) -> Result<(), anyhow::Error> {
         let file = File::create(path)?;
         serde_json::to_writer_pretty(file, self)?;
         Ok(())

--- a/src/gpu_status_file.rs
+++ b/src/gpu_status_file.rs
@@ -1,0 +1,44 @@
+use std::{
+    fs::File,
+    io::BufReader,
+    path::{Path, PathBuf},
+};
+
+use anyhow;
+
+#[derive(serde::Deserialize, serde::Serialize, Debug, Clone)]
+pub(crate) struct GpuStatusFile {
+    pub num_devices: u32,
+    pub device_names: Vec<String>,
+}
+
+impl Default for GpuStatusFile {
+    fn default() -> Self {
+        Self {
+            num_devices: 0,
+            device_names: vec![],
+        }
+    }
+}
+
+impl GpuStatusFile {
+    pub const fn new(num_devices: u32, device_names: Vec<String>) -> Self {
+        Self {
+            num_devices,
+            device_names,
+        }
+    }
+
+    pub(crate) fn load(path: &PathBuf) -> Result<Self, anyhow::Error> {
+        let file = File::open(path)?;
+        let reader = BufReader::new(file);
+        let config = serde_json::from_reader(reader)?;
+        Ok(config)
+    }
+
+    pub(crate) fn save(&self, path: &Path) -> Result<(), anyhow::Error> {
+        let file = File::create(path)?;
+        serde_json::to_writer_pretty(file, self)?;
+        Ok(())
+    }
+}

--- a/src/http/server.rs
+++ b/src/http/server.rs
@@ -13,6 +13,9 @@ use crate::{
     stats_store::StatsStore,
 };
 
+use log::info;
+const LOG_TARGET: &str = "tari::gpuminer::server";
+
 /// An HTTP server that provides stats and other useful information.
 pub struct HttpServer {
     shutdown_signal: ShutdownSignal,
@@ -53,10 +56,12 @@ impl HttpServer {
     /// Starts the http server on the port passed in ['HttpServer::new']
     pub async fn start(&self) -> Result<(), Error> {
         let router = self.routes();
-        let listener = tokio::net::TcpListener::bind(format!("0.0.0.0:{}", self.config.port))
+        let listener = tokio::net::TcpListener::bind(format!("127.0.0.1:{}", self.config.port))
             .await
             .map_err(Error::IO)?;
         println!("Starting HTTP server at http://127.0.0.1:{}", self.config.port);
+        println!("Starting HTTP listener address {:?}", listener.local_addr());
+        info!(target: LOG_TARGET, "Starting HTTP listener address {:?}", listener.local_addr());
         axum::serve(listener, router)
             .with_graceful_shutdown(self.shutdown_signal.clone())
             .await

--- a/src/opencl_engine.rs
+++ b/src/opencl_engine.rs
@@ -17,7 +17,9 @@ use opencl3::{
     types::{cl_ulong, CL_TRUE},
 };
 
-use crate::{context_impl::ContextImpl, engine_impl::EngineImpl, function_impl::FunctionImpl};
+use crate::{
+    context_impl::ContextImpl, engine_impl::EngineImpl, function_impl::FunctionImpl, gpu_status_file::GpuStatus,
+};
 
 const LOG_TARGET: &str = "tari::gpuminer::opencl";
 
@@ -52,46 +54,41 @@ impl EngineImpl for OpenClEngine {
 
     fn num_devices(&self) -> Result<u32, anyhow::Error> {
         let mut total_devices = 0;
-        let mut device_names = vec![];
         let lock = self.inner.read().unwrap();
         for platform in lock.platforms.iter() {
             let devices = platform.get_devices(CL_DEVICE_TYPE_GPU)?;
-            info!(target: LOG_TARGET, "OpenClEngine: platform name: {}", platform.name()?);
-            println!("Platform: {}", platform.name()?);
-            println!("Devices: ");
-            for device in devices {
-                let dev = Device::new(device);
-                let name = dev.name().unwrap_or_default() as String;
-                info!(target: LOG_TARGET, "Device: {}", dev.name()?);
-                println!("Device: {}", dev.name()?);
-                total_devices += 1;
-                device_names.push(name);
-            }
+            total_devices += devices.len();
         }
-        info!(target: LOG_TARGET, "OpenClEngine: num_devices {:?}", total_devices);
-        Ok(total_devices)
+        info!(target: LOG_TARGET, "OpenClEngine: total number of devices {:?}", total_devices);
+        Ok(total_devices as u32)
     }
 
-    fn list_devices(&self) -> Result<Vec<String>, anyhow::Error> {
+    fn detect_devices(&self) -> Result<Vec<GpuStatus>, anyhow::Error> {
         let mut total_devices = 0;
-        let mut device_names = vec![];
+        let mut gpu_devices: Vec<GpuStatus> = vec![];
         let lock = self.inner.read().unwrap();
         for platform in lock.platforms.iter() {
             let devices = platform.get_devices(CL_DEVICE_TYPE_GPU)?;
+
             info!(target: LOG_TARGET, "OpenClEngine: platform name: {}", platform.name()?);
-            println!("Platform: {}", platform.name()?);
-            println!("Devices: ");
+            println!("List of the devices for the Platform: {}", platform.name()?);
             for device in devices {
                 let dev = Device::new(device);
                 let name = dev.name().unwrap_or_default() as String;
-                info!(target: LOG_TARGET, "Device: {}", dev.name()?);
-                println!("Device: {}", dev.name()?);
+                info!(target: LOG_TARGET, "Device index {:?}: {}", total_devices, &name);
+                println!("device: {}", &name);
+                let mut gpu = GpuStatus {
+                    device_name: name,
+                    is_available: true,
+                };
+                gpu_devices.push(gpu);
                 total_devices += 1;
-                device_names.push(name);
             }
         }
-        info!(target: LOG_TARGET, "OpenClEngine: num_devices {:?}", total_devices);
-        Ok(device_names)
+        if total_devices > 0 {
+            return Ok(gpu_devices);
+        }
+        return Err(anyhow::anyhow!("No gpu device detected"));
     }
 
     fn create_context(&self, device_index: u32) -> Result<Self::Context, anyhow::Error> {

--- a/src/opencl_engine.rs
+++ b/src/opencl_engine.rs
@@ -52,6 +52,7 @@ impl EngineImpl for OpenClEngine {
 
     fn num_devices(&self) -> Result<u32, anyhow::Error> {
         let mut total_devices = 0;
+        let mut device_names = vec![];
         let lock = self.inner.read().unwrap();
         for platform in lock.platforms.iter() {
             let devices = platform.get_devices(CL_DEVICE_TYPE_GPU)?;
@@ -60,13 +61,37 @@ impl EngineImpl for OpenClEngine {
             println!("Devices: ");
             for device in devices {
                 let dev = Device::new(device);
+                let name = dev.name().unwrap_or_default() as String;
                 info!(target: LOG_TARGET, "Device: {}", dev.name()?);
                 println!("Device: {}", dev.name()?);
                 total_devices += 1;
+                device_names.push(name);
             }
         }
         info!(target: LOG_TARGET, "OpenClEngine: num_devices {:?}", total_devices);
         Ok(total_devices)
+    }
+
+    fn list_devices(&self) -> Result<Vec<String>, anyhow::Error> {
+        let mut total_devices = 0;
+        let mut device_names = vec![];
+        let lock = self.inner.read().unwrap();
+        for platform in lock.platforms.iter() {
+            let devices = platform.get_devices(CL_DEVICE_TYPE_GPU)?;
+            info!(target: LOG_TARGET, "OpenClEngine: platform name: {}", platform.name()?);
+            println!("Platform: {}", platform.name()?);
+            println!("Devices: ");
+            for device in devices {
+                let dev = Device::new(device);
+                let name = dev.name().unwrap_or_default() as String;
+                info!(target: LOG_TARGET, "Device: {}", dev.name()?);
+                println!("Device: {}", dev.name()?);
+                total_devices += 1;
+                device_names.push(name);
+            }
+        }
+        info!(target: LOG_TARGET, "OpenClEngine: num_devices {:?}", total_devices);
+        Ok(device_names)
     }
 
     fn create_context(&self, device_index: u32) -> Result<Self::Context, anyhow::Error> {


### PR DESCRIPTION
Create gpu_status.json file when detecting gpu devices. Information about the name and availability can be then used in Tari Universe.
File is saved in the same folder as `config.json` gpu file, so `.config/com.tari.universe/gpuminer/gpu_status.json`
Example of the json file
```
{
  "gpu_devices": [
    {
      "device_name": "Intel(R) Iris(R) Xe Graphics [0x9a49]",
      "is_available": true
    }
  ]
}
```