### PR TITLE
chore(ci): fix cross-compile warning for getrandom

### DIFF
--- a/.github/workflows/build_binaries.yml
+++ b/.github/workflows/build_binaries.yml
@@ -234,6 +234,8 @@ jobs:
           #cargo install cross
           cargo install cross --git https://github.com/cross-rs/cross
           echo "CARGO=cross" >> $GITHUB_ENV
+          # Disable - [cross] warning: Found conflicting cross configuration
+          echo "CROSS_NO_WARNINGS=0" >> $GITHUB_ENV
 
       - name: Install and setup cargo-auditable
         # if: ${{ ( startsWith(github.ref, 'refs/tags/v') ) && ( ! matrix.builds.cross ) }}


### PR DESCRIPTION
Fix build for cross-compiled platforms - linux-arm64/linux-riscv
Seems there is a multi version conflict in getrandom crate
